### PR TITLE
Adjust git clone (clone only the tip of the tag / branch).

### DIFF
--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -213,7 +213,8 @@ function git_clone {
 
   echo -e "${GREEN}Cloning into ${CYAN}mx-chain-$ENVIRONMENT-config${GREEN} with tag ${CYAN}$CONFIGVER${GREEN}...${NC}"
   echo -e
-  cd $GOPATH/src/github.com/multiversx && git clone https://github.com/multiversx/mx-chain-"$ENVIRONMENT"-config && cd mx-chain-"$ENVIRONMENT"-config && git checkout --force $CONFIGVER
+  CONFIGVER_SHORT=$(echo $CONFIGVER | sed 's/tags\///')
+  cd $GOPATH/src/github.com/multiversx && git clone https://github.com/multiversx/mx-chain-"$ENVIRONMENT"-config --branch=$CONFIGVER_SHORT --single-branch --depth=1
   echo -e
   
   #Get mx-chain-go binary version from the mx-chain-$ENVIRONMENT-config repo
@@ -222,7 +223,8 @@ function git_clone {
   echo -e
   echo -e "${GREEN}Cloning into ${CYAN}mx-chain-go${GREEN} with tag ${CYAN}$BINARYVER${GREEN}...${NC}"
   echo -e
-  cd $GOPATH/src/github.com/multiversx && git clone https://github.com/multiversx/mx-chain-go && cd mx-chain-go && git checkout --force $BINARYVER
+  BINARYVER_SHORT=$(echo $BINARYVER | sed 's/tags\///')
+  cd $GOPATH/src/github.com/multiversx && git clone https://github.com/multiversx/mx-chain-go --branch=$BINARYVER_SHORT --single-branch --depth=1
   
   echo -e "${GREEN}Done ! Moving to next step...${NC}"
   echo -e
@@ -235,7 +237,8 @@ function git_clone_proxy {
   echo -e
   echo -e "${GREEN}Cloning into the ${CYAN}mx-chain-proxy-go${GREEN} and checking out ${CYAN}${PROXY_TAG}${GREEN}...${NC}"
   echo -e
-  cd $GOPATH/src/github.com/multiversx && git clone https://github.com/multiversx/mx-chain-proxy-go.git && cd mx-chain-proxy-go && git checkout $PROXY_TAG
+  PROXY_TAG_SHORT=$(echo $PROXY_TAG | sed 's/tags\///')
+  cd $GOPATH/src/github.com/multiversx && git clone https://github.com/multiversx/mx-chain-proxy-go.git --branch=$PROXY_TAG_SHORT --single-branch --depth=1
   
   echo -e "${GREEN}Done ! Moving to next step...${NC}"
   echo -e


### PR DESCRIPTION
Use `--single-branch` and `--depth=1` when cloning git repositories (improvement in download time).

Similar to what we have on the Rosetta setup:

https://github.com/multiversx/mx-chain-rosetta-docker/blob/main/Dockerfile#L14