### PR TITLE
Fix go version compare

### DIFF
--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -133,7 +133,7 @@ function go_lang {
       else
           #Check the installed version number
           GOVERSION=$(go version | awk '{print $3}' | sed 's/go//')
-          if dpkg --compare-versions "$GOVERSION" "lt" "${GO_LATEST_TESTED}"; then
+          if [[ "$GOVERSION" != "$GO_LATEST_TESTED" ]]; then
                 echo -e
                 echo -e "${RED}GO version is ${CYAN}$GOVERSION${RED} and the best working version is ${CYAN}${GO_LATEST_TESTED}${RED}... ${NC}"
                 #Detect go install method
@@ -144,9 +144,9 @@ function go_lang {
                             echo -e
                             echo -e "${GREEN}Your GO binary will pe upgraded to the minimum required version...${NC}"
                             sudo rm -rf /usr/local/go
-                            wget -4 https://dl.google.com/go/${GO_LATEST_TESTED}.linux-${ARCH}.tar.gz
-                            sudo tar -C /usr/local -xzf ${GO_LATEST_TESTED}.linux-${ARCH}.tar.gz
-                            rm ${GO_LATEST_TESTED}.linux-${ARCH}.tar.gz
+                            wget -4 https://dl.google.com/go/go${GO_LATEST_TESTED}.linux-${ARCH}.tar.gz
+                            sudo tar -C /usr/local -xzf go${GO_LATEST_TESTED}.linux-${ARCH}.tar.gz
+                            rm go${GO_LATEST_TESTED}.linux-${ARCH}.tar.gz
 
                         else
                         echo -e

--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -118,7 +118,7 @@ function go_lang {
   ARCH=$(dpkg --print-architecture)
 
   #Check if golang is installed on system
-  if ! [ -x "$(command -v go)" ]; then
+  if ! command -v go &>/dev/null; then
         #Get the latest version of GO for amd64 & installing it
         echo -e
         echo -e "${RED}GO is not installed on your system${NC}"
@@ -132,8 +132,8 @@ function go_lang {
 
       else
           #Check the installed version number
-          GOVERSION=$(go version | awk '{print $3}')
-          if [[ "$GOVERSION" < "${GO_LATEST_TESTED}" ]]; then
+          GOVERSION=$(go version | awk '{print $3}' | sed 's/go//')
+          if dpkg --compare-versions "$GOVERSION" "lt" "${GO_LATEST_TESTED}"; then
                 echo -e
                 echo -e "${RED}GO version is ${CYAN}$GOVERSION${RED} and the best working version is ${CYAN}${GO_LATEST_TESTED}${RED}... ${NC}"
                 #Detect go install method
@@ -151,7 +151,7 @@ function go_lang {
                         else
                         echo -e
                         echo -e "${RED}GO was not installed using the elrond scripts. Operation cannot continue...${NC}"
-                        exit
+                        exit 1
                     fi
               
                 else

--- a/config/functions.cfg
+++ b/config/functions.cfg
@@ -126,9 +126,9 @@ function go_lang {
         echo -e "${GREEN}The best working version of Go is:${CYAN}${GO_LATEST_TESTED}${NC}"
         echo -e "${GREEN}Installing it now...${NC}"
         echo -e
-        wget https://dl.google.com/go/${GO_LATEST_TESTED}.linux-${ARCH}.tar.gz
-        sudo tar -C /usr/local -xzf ${GO_LATEST_TESTED}.linux-${ARCH}.tar.gz
-        rm ${GO_LATEST_TESTED}.linux-${ARCH}.tar.gz
+        wget https://dl.google.com/go/go${GO_LATEST_TESTED}.linux-${ARCH}.tar.gz
+        sudo tar -C /usr/local -xzf go${GO_LATEST_TESTED}.linux-${ARCH}.tar.gz
+        rm go${GO_LATEST_TESTED}.linux-${ARCH}.tar.gz
 
       else
           #Check the installed version number

--- a/config/variables.cfg
+++ b/config/variables.cfg
@@ -42,7 +42,7 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 #Use the latest MultiversX tested GO Lang version
 #This will be overwritten with the config value if a goVersion file is provided.
 #It will be deprecated once all public chains switch to goVersion file config.
-GO_LATEST_TESTED="go1.20.7"
+GO_LATEST_TESTED="1.20.7"
 
 #Obtain the tag for the latest version node & configs
 TMPVAR="tags/"


### PR DESCRIPTION
- Added a more robust version check for go version (previous iteration failed if installed version was newer)
- changed the $GO_LATEST_TESTED variable default value
- updated all go download script lines to reflect the change